### PR TITLE
Implement healthcheck endpoint at '/status'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,5 +92,8 @@ ENV OVOS_CONFIG_STATIC_DIR=/app/static
 # Expose the default port
 EXPOSE 8000
 
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=60s \
+    CMD curl http://127.0.0.1:8000/status || kill 1
+    
 # Command to run the application using the installed script
 CMD ["ovos-skill-config-tool"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,6 @@ ENV OVOS_CONFIG_STATIC_DIR=/app/static
 EXPOSE 8000
 
 HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=60s \
-    CMD curl http://127.0.0.1:8000/status || kill 1
-    
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/status', timeout=5)" || kill 1
 # Command to run the application using the installed script
 CMD ["ovos-skill-config-tool"]

--- a/ovos_skill_config/main.py
+++ b/ovos_skill_config/main.py
@@ -43,6 +43,12 @@ app.add_middleware(
 )
 
 
+# No auth - for healthchecks
+@app.get("/status")
+async def status(request: Request):
+    return {"status": "ok"}
+
+
 @app.post("/api/v1/auth/login")
 async def login(request: Request):
     auth_header = request.headers.get("Authorization")

--- a/ovos_skill_config/main.py
+++ b/ovos_skill_config/main.py
@@ -45,7 +45,7 @@ app.add_middleware(
 
 # No auth - for healthchecks
 @app.get("/status")
-async def status(request: Request):
+async def healthcheck_status(request: Request):
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
Completes #29 (JarbasAl) — both his commits are preserved as-is with original authorship, plus two fixes on top:

1. **`curl` → `python`/`urllib` in the Dockerfile `HEALTHCHECK`** — addresses Mike's review comment on #29: `curl` isn't installed in the final image (only in the `backend-builder` stage, to fetch the `uv` binary). Swapped to `urllib.request`, already available via the Python already on `PATH`, no extra package needed.
2. **Renamed the `/status` route handler** — JarbasAl's `async def status(...)` shadowed the module-level `from fastapi import ... status` import for every reference below it in the file, breaking every `status.HTTP_*` constant used in auth error responses. This wasn't caught in the original review (which only covered the Dockerfile) — the existing test suite caught it once both commits landed here (4 failures → 0). Route path (`/status`) is unchanged, only the Python identifier.

Closes #29.

## Test plan
- [x] `just test` — 28/28 pass (was 24/28 before the rename fix)
- [x] `docker build` + `docker run`, `docker inspect --format='{{.State.Health.Status}}'` reports `healthy`
- [x] Confirmed `curl` is genuinely absent in the final image (`which curl` → exit 1), and the container log shows a real `GET /status HTTP/1.1" 200 OK` from the healthcheck itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)